### PR TITLE
Make all response types use the getStatusCode method

### DIFF
--- a/src/MSApplicationInsightsHelpers.php
+++ b/src/MSApplicationInsightsHelpers.php
@@ -306,6 +306,6 @@ class MSApplicationInsightsHelpers
      */
     private function getResponseCode($response)
     {
-        return $response instanceof StreamedResponse ? $response->getStatusCode() : $response->status();
+        return $response instanceof Response ? $response->getStatusCode() : $response->status();
     }
 }


### PR DESCRIPTION
Currently, for objects that aren't of type `StreamedResponse`, we are trying to use the `$response->status()` method. This is causing an error for `BinaryFileResponse` types as they do not have a `status()` method. 

Both `StreamedResponse` and `BinaryFileResponse` inherit from `Response`, which has the `getStatusCode()` method.

Also, the `$response->status()` method on the `ResponseTrait` inevitably calls `$this->getStatusCode()` anyway, so this piece of code seems unnecessary

- Use `getStatusCode` for all $response variables of type `Response`. This will fix the error.
