### PR TITLE
Consistently retrieve the response status code

### DIFF
--- a/src/MSApplicationInsightsHelpers.php
+++ b/src/MSApplicationInsightsHelpers.php
@@ -58,7 +58,7 @@ class MSApplicationInsightsHelpers
                     $request->fullUrl(),
                     $_SERVER['REQUEST_TIME_FLOAT'],
                     $this->getRequestDuration(),
-                    $this->getResponseCode($response),
+                    $response->getStatusCode(),
                     $this->isSuccessful($response),
                     $this->getRequestProperties($request),
                     $this->getRequestMeasurements($request, $response)
@@ -227,7 +227,7 @@ class MSApplicationInsightsHelpers
      */
     private function isSuccessful($response)
     {
-        return ($this->getResponseCode($response) < 400);
+        return $response->getStatusCode() < 400;
     }
 
 
@@ -294,18 +294,5 @@ class MSApplicationInsightsHelpers
         $days = floor($duration / 86400);
 
         return $days . ':' . $string;
-    }
-
-    /**
-     * If you use stream() or streamDownload() then the response object isn't a standard one. Here we check different
-     * places for the status code depending on the object that Laravel sends us.
-     *
-     * @param StreamedResponse|Response $response The response object
-     *
-     * @return int The HTTP status code
-     */
-    private function getResponseCode($response)
-    {
-        return $response instanceof Response ? $response->getStatusCode() : $response->status();
     }
 }


### PR DESCRIPTION
Remove the conditional check here as the `$response->status()` method on the `Response` trait ends up calling `$response->getStatusCode()` anyway so the code is superfluous