### PR TITLE
NEW Allow installation against PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "role": "Developer"
     }],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "laravel/framework": "^8.0"
     },
     "autoload": {


### PR DESCRIPTION
Haven't hit any issues with code compatibility, so this should be all that's required for PHP 8 support.